### PR TITLE
Added dual class action bar listeners to m_c0sas1.lua

### DIFF
--- a/shadowadept/lua/m_c0sas1.lua
+++ b/shadowadept/lua/m_c0sas1.lua
@@ -57,3 +57,23 @@ function ArtisanNightsingerActionbarListener(config, state)
    end
 end
 EEex_Actionbar_AddListener(ArtisanNightsingerActionbarListener)
+
+function ArtisanFighterShadowAdeptDualActionbarListener(config, state)
+   if 
+      state == 7
+      and EEex_GameObject_GetSelected():getActiveStats().m_nKit == Shadow_Adept_IDS
+      then
+      EEex_Actionbar_SetButton(5, EEex_Actionbar_ButtonType.STEALTH)
+   end
+end
+EEex_Actionbar_AddListener(ArtisanFighterShadowAdeptDualActionbarListener)
+
+function ArtisanClericShadowAdeptDualActionbarListener(config, state)
+   if 
+      state == 14
+      and EEex_GameObject_GetSelected():getActiveStats().m_nKit == Shadow_Adept_IDS
+      then
+      EEex_Actionbar_SetButton(5, EEex_Actionbar_ButtonType.STEALTH)
+   end
+end
+EEex_Actionbar_AddListener(ArtisanClericShadowAdeptDualActionbarListener)


### PR DESCRIPTION
# Added dual class action bar listeners to m_c0sas1.lua

## Issue

After dual-classing to `Shadow Adept` using the `Shadow Orb` on a `Fighter → Mage` or `Cleric → Mage` (or the other way around) when both classes become active the action bar doesn't show `Hide in Shadows` button. 

## Fix

Added action bar listeners that add `Hide in Shadows` button to `Shadow Adept` kitted action bar states `7 - Fighter Mage` and `14 - Cleric Mage`.

This adds the `Hide in Shadows` button to: `Shadow Adept → Fighter`, `Fighter → Shadow Adept`, `Shadow Adept → Cleric`, `Cleric → Shadow Adept`).

## Tests

Manually tested on a newly installed BG1EE v2.6.6.0 with EEex and Shadow Magic only.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update